### PR TITLE
Remove src from npmignore

### DIFF
--- a/packages/react-data-grid-addons/.npmignore
+++ b/packages/react-data-grid-addons/.npmignore
@@ -1,4 +1,3 @@
-src
 .npmrc
 secure-file
 npm-debug.log


### PR DESCRIPTION
Source files should not be left out of the published build, it's a library that's meant to be compiled by the developer!
(it's also currently broken on npm ;) )

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: code published on npm was not working
```

**What is the current behavior?** (You can also link to an open issue here)
`import { Toolbar } from 'react-data-grid-addons'` did not work because the source files were not published to npm


**What is the new behavior?**
source files should now be published with npm publish -- I did not test it, but it's a minor change.
feel free to test it before publishing, but the current published version is not working


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

I did not test it, but it's a minor change, I edited it with the github web editor, and can't see what could go wrong.

feel free to [test it](http://podefr.tumblr.com/post/30488475488/locally-test-your-npm-modules-without-publishing) before publishing.